### PR TITLE
Add line-height to paragraph and font-family to input

### DIFF
--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -155,11 +155,13 @@
     flex: 1;
     margin: 0px 15px;
     font-size: 22px;
+    line-height: 28px;
     word-wrap: break-word;
     min-width: 0;
   }
 
   input.todo-text {
+    font-family: inherit;
     background-color: transparent;
     color: var(--theme-input-text);
     margin: 0px 10px;


### PR DESCRIPTION
Add line-height: 28px to .todo-text and font-family: inherit to input.todo-text to ensure vertical alignment between text and input field during editing mode.