### PR TITLE
Remove old logic, comments and simplify 'EDIT-TODO' in reducer

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -64,7 +64,7 @@ const TodoItem: FC<TodoItemProps> = memo(({ index, todo, dispatch }) => {
     }
     dispatch({
       type: 'EDIT-TODO',
-      payload: { id: todo.id, editTodoText, target: 'todos' },
+      payload: { id: todo.id, editTodoText },
     });
     setEdit(false);
   };

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -65,16 +65,10 @@ const TodoItem: FC<TodoItemProps> = memo(({ index, todo, dispatch }) => {
       toggleModal();
       return;
     }
-
     dispatch({
       type: 'EDIT-TODO',
       payload: { id: todo.id, editTodoText, target: 'todos' },
     });
-    // dispatch({
-    // 	type: 'EDIT-TODO',
-    // 	payload: { id, editTodoText, target: 'doneTodos' },
-    // });
-
     setEdit(false);
   };
 

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -21,7 +21,6 @@ interface TodoItemProps {
   dispatch: Dispatch<TodoActions>;
 }
 
-// * Check this component and functions on right using todos and doneTodos
 const TodoItem: FC<TodoItemProps> = memo(({ index, todo, dispatch }) => {
   const [edit, setEdit] = useState(false);
   const [editTodoText, setEditTodoText] = useState<string>(todo.todoText);
@@ -58,8 +57,6 @@ const TodoItem: FC<TodoItemProps> = memo(({ index, todo, dispatch }) => {
     setIsModalOpen((prevIsModalOpen) => !prevIsModalOpen);
   };
 
-  //TODO: Review this function and where it's using below this code, because uses only for todos not for doneTodos
-  //TODO: Consider adding a condition for an empty string
   const handleSaveEdit = (): void => {
     if (editTodoText.trim().length === 0) {
       toggleModal();

--- a/src/context/todoReducer.ts
+++ b/src/context/todoReducer.ts
@@ -16,7 +16,7 @@ export type TodoActions =
       payload: {
         id: string;
         editTodoText: string;
-        target: Target;
+        target?: Target;
       };
     }
   | {
@@ -82,7 +82,7 @@ const todoReducer = (
     case 'EDIT-TODO':
       return {
         ...state,
-        [payload.target]: targetArray.map((todo) =>
+        todos: todos.map((todo) =>
           todo.id === payload.id
             ? { ...todo, todoText: payload.editTodoText }
             : todo


### PR DESCRIPTION
1. Removed unused commented dispatch function in 'ItemTodo' component.
2. Cleaned up unnecessary comments.
3. Removed 'target' field from dispatch function.
4. Added optional operator '?' to 'target' field in 'TodoActions' type for 'EDIT-TODO' case.
5. Replaced '[payload.target]' and 'targetArray' with 'todos' array in 'EDIT-TODO' case.