### PR TITLE
Create useModal hook and replace duplicated modal logic

### DIFF
--- a/src/components/CreateTodo.tsx
+++ b/src/components/CreateTodo.tsx
@@ -1,24 +1,21 @@
 import { FC, FormEvent, useRef, useContext, useState } from 'react';
 import { PiPlusBold } from 'react-icons/pi';
 import Modal from './Modal';
+import { useModal } from '../hooks/useModal';
 import { TodoContext } from '../context/TodoContext';
 import './styles.scss';
 
 const CreateTodo: FC = () => {
   const [todoText, setTodoText] = useState('');
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { isModalOpen, openModal, closeModal } = useModal();
   const { dispatch } = useContext(TodoContext);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const toggleModal = (): void => {
-    setIsModalOpen((prevIsModalOpen) => !prevIsModalOpen);
-  };
 
   const handleSubmitTodo = (event: FormEvent): void => {
     event.preventDefault();
 
     if (todoText.trim().length === 0) {
-      toggleModal();
+      openModal();
       setTodoText('');
       return;
     }
@@ -53,7 +50,7 @@ const CreateTodo: FC = () => {
       </form>
       {isModalOpen && (
         <Modal
-          onClose={toggleModal}
+          onClose={closeModal}
           title="Error"
           message="A task cannot have an empty field."
         />

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -12,6 +12,7 @@ import { MdDoneOutline } from 'react-icons/md';
 import { RiArrowGoBackFill } from 'react-icons/ri';
 import { Draggable } from '@hello-pangea/dnd';
 import Modal from './Modal';
+import { useModal } from '../hooks/useModal';
 import { Target, TodoActions } from '../context/todoReducer';
 import { Todo } from '../models';
 
@@ -24,7 +25,7 @@ interface TodoItemProps {
 const TodoItem: FC<TodoItemProps> = memo(({ index, todo, dispatch }) => {
   const [edit, setEdit] = useState(false);
   const [editTodoText, setEditTodoText] = useState<string>(todo.todoText);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { isModalOpen, openModal, closeModal } = useModal();
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -53,13 +54,9 @@ const TodoItem: FC<TodoItemProps> = memo(({ index, todo, dispatch }) => {
     }
   };
 
-  const toggleModal = () => {
-    setIsModalOpen((prevIsModalOpen) => !prevIsModalOpen);
-  };
-
   const handleSaveEdit = (): void => {
     if (editTodoText.trim().length === 0) {
-      toggleModal();
+      openModal();
       return;
     }
     dispatch({
@@ -158,7 +155,7 @@ const TodoItem: FC<TodoItemProps> = memo(({ index, todo, dispatch }) => {
       </Draggable>
       {isModalOpen && (
         <Modal
-          onClose={toggleModal}
+          onClose={closeModal}
           title="Error"
           message="The already created task cannot be empty. Edit it correctly."
         />

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+interface UseModalReturn {
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+export const useModal = (): UseModalReturn => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = () => setIsModalOpen(true);
+
+  const closeModal = () => setIsModalOpen(false);
+
+  return { isModalOpen, openModal, closeModal };
+};


### PR DESCRIPTION
1. Created useModal hook to manage modal window state.
2. Replaced the duplicated modal state logic with useModal hook, which provides better support and usability.