### PR TITLE
fix: add vertical paddings to header

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -5,6 +5,7 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   column-gap: 15px;
+  padding: 15px 0 20px;
 }
 
 .title {


### PR DESCRIPTION
Added vertical paddings (15px top / 20px bottom) to the header. This ensures visual balance and prevents title clumping when it wraps to multiple lines on mobile devices.