### PR TITLE
fix: eliminate theme flash and layout shift using useLayoutEffect

### DIFF
--- a/src/context/TaskContext.tsx
+++ b/src/context/TaskContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, ReactNode, useReducer, useEffect } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useReducer,
+  useEffect,
+  useLayoutEffect,
+} from 'react';
 import { InitialState, TaskContextProps, Task } from '@typings/taskTypes';
 import { taskReducer } from '@context/taskReducer';
 import { saveToStorage, getFromStorage } from '@utils/localStorage';
@@ -17,7 +23,8 @@ const TaskContextProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(taskReducer, initialState);
   const { activeTasks, completedTasks } = state;
 
-  useEffect(() => {
+  // Use layout effect to prevent layout shift (scrollbar jump) on initial render.
+  useLayoutEffect(() => {
     const storedActiveTasks = getFromStorage<Task[] | null>('activeTasks');
     const storedCompletedTasks = getFromStorage<Task[] | null>(
       'completedTasks'

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { getFromStorage, saveToStorage } from '@utils/localStorage';
 import { THEMES, Theme } from '@constants/themeList';
 
@@ -10,7 +10,8 @@ interface UseThemeReturn {
 export const useTheme = (): UseThemeReturn => {
   const [theme, setTheme] = useState<Theme | ''>('');
 
-  useEffect(() => {
+  // Use layout effect to prevent theme flash on initial render.
+  useLayoutEffect(() => {
     const storedTheme = getFromStorage<Theme | null>('theme');
 
     if (storedTheme) {


### PR DESCRIPTION
### Problem
**Visual defects on initial render:**
* **Theme Flash**: Brief absence of theme colors (content is displayed on the browser's default white background until the theme is applied).
* **Layout Shift**: Sudden content shift caused by the scrollbar appearing when the task list exceeds the viewport height.

### Solution
Applied **`useLayoutEffect`** for theme and tasks initialization. This ensures **DOM synchronization** before the browser's first paint, eliminating theme flash and layout shift.