### PR TITLE
fix: initialize theme before first paint to eliminate flash on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,24 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      // Initialize theme before first paint to prevent flash on iOS
+      (function () {
+        let theme = 'light';
+        try {
+          const storedTheme = JSON.parse(localStorage.getItem('theme'));
+          if (storedTheme) {
+            theme = storedTheme;
+          } else {
+            const systemTheme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            theme = systemTheme;
+          }
+        } catch {
+        } finally {
+          document.documentElement.setAttribute('data-theme', theme);
+        }
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lato&display=swap" rel="stylesheet">

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from 'react';
-import { getFromStorage, saveToStorage } from '@utils/localStorage';
+import { saveToStorage } from '@utils/localStorage';
 import { THEMES, Theme } from '@constants/themeList';
 
 interface UseThemeReturn {
@@ -10,18 +10,13 @@ interface UseThemeReturn {
 export const useTheme = (): UseThemeReturn => {
   const [theme, setTheme] = useState<Theme | ''>('');
 
-  // Use layout effect to prevent theme flash on initial render.
+  // Use layout effect to prevent theme icon flickering on initial render
   useLayoutEffect(() => {
-    const storedTheme = getFromStorage<Theme | null>('theme');
-
-    if (storedTheme) {
-      setTheme(storedTheme);
-    } else {
-      const systemTheme = matchMedia('(prefers-color-scheme: dark)').matches
-        ? THEMES.DARK
-        : THEMES.LIGHT;
-      setTheme(systemTheme);
-    }
+    // Sync state with the theme initialized by the blocking script in index.html
+    const initialTheme = document.documentElement.getAttribute(
+      'data-theme'
+    ) as Theme;
+    setTheme(initialTheme || THEMES.LIGHT);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
**Note:** `useLayoutEffect` doesn't fire early enough to prevent **theme flash** in WebKit (Safari/iOS). Using a **blocking inline script** in `<head>` ensures the theme is applied before first paint.