### PR TITLE
fix: disable sticky hover on touch devices

### DIFF
--- a/src/components/CreateTask/CreateTask.module.scss
+++ b/src/components/CreateTask/CreateTask.module.scss
@@ -64,9 +64,11 @@
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
   z-index: 2;
 
-  &:hover {
-    color: #fff;
-    background-color: #80a8c0;
+  @include hover-supported {
+    &:hover {
+      color: #fff;
+      background-color: #80a8c0;
+    }
   }
 
   &:active {

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -27,8 +27,10 @@
   border-radius: 10px;
   transition: background-color, 0.2s;
 
-  &:hover {
-    background-color: rgba(175, 202, 224, 0.5);
+  @include hover-supported {
+    &:hover {
+      background-color: rgba(175, 202, 224, 0.5);
+    }
   }
 
   & svg {

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -56,8 +56,10 @@
     transition: transform 0.2s;
   }
 
-  &:hover svg {
-    transform: rotate(90deg);
+  @include hover-supported {
+    &:hover svg {
+      transform: rotate(90deg);
+    }
   }
 }
 

--- a/src/components/TaskItem/TaskItem.module.scss
+++ b/src/components/TaskItem/TaskItem.module.scss
@@ -1,8 +1,3 @@
-%hover-active-effect {
-  box-shadow: 0 0 5px #333;
-  background-color: rgba(255, 255, 255, 0.3);
-}
-
 .taskItem {
   display: flex;
   border-radius: 10px;
@@ -14,12 +9,16 @@
     box-shadow 0.3s;
   animation: appear 0.5s;
 
-  &:hover {
-    @extend %hover-active-effect;
+  @include hover-supported {
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.3);
+      box-shadow: 0 0 5px #333;
+    }
   }
 
   &:active {
-    @extend %hover-active-effect;
+    background-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 0 5px #333;
     cursor: grabbing;
   }
 }
@@ -63,8 +62,10 @@ input.text {
     transition: transform 0.2s;
   }
 
-  &:hover svg {
-    transform: scale(1.2);
+  @include hover-supported {
+    &:hover svg {
+      transform: scale(1.2);
+    }
   }
 
   &:active svg {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -9,3 +9,9 @@
   height: $height;
   flex-shrink: 0;
 }
+
+@mixin hover-supported {
+  @media (hover: hover) and (pointer: fine) {
+    @content;
+  }
+}


### PR DESCRIPTION
**Note:** In `TaskItem`, replaced placeholder with duplicated styles to resolve Sass `@extend` limitations within media queries.