### PR TITLE
feat: add visual feedback during task dragging

### DIFF
--- a/src/components/TaskItem/TaskItem.module.scss
+++ b/src/components/TaskItem/TaskItem.module.scss
@@ -1,3 +1,8 @@
+@mixin _task-item-highlight {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 5px #333;
+}
+
 .taskItem {
   display: flex;
   border-radius: 10px;
@@ -11,15 +16,17 @@
 
   @include hover-supported {
     &:hover {
-      background-color: rgba(255, 255, 255, 0.3);
-      box-shadow: 0 0 5px #333;
+      @include _task-item-highlight;
     }
   }
 
   &:active {
-    background-color: rgba(255, 255, 255, 0.3);
-    box-shadow: 0 0 5px #333;
+    @include _task-item-highlight;
     cursor: grabbing;
+  }
+
+  &.isDragging {
+    @include _task-item-highlight;
   }
 }
 

--- a/src/components/TaskItem/TaskItem.tsx
+++ b/src/components/TaskItem/TaskItem.tsx
@@ -85,10 +85,10 @@ const TaskItem: FC<TaskItemProps> = memo(({ index, task, dispatch }) => {
 
   return (
     <>
-      <Draggable draggableId={task.id.toString()} index={index}>
-        {(provided) => (
+      <Draggable draggableId={task.id} index={index}>
+        {(provided, snapshot) => (
           <li
-            className={styles.taskItem}
+            className={`${styles.taskItem} ${snapshot.isDragging ? styles.isDragging : ''}`}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
             ref={provided.innerRef}


### PR DESCRIPTION
**Notes:**
- Added `isDragging` class to maintain visual feedback during the entire drag process.
- Added local `_task-item-highlight` mixin to unify hover, active, and dragging states without duplication.