### PR TITLE
fix: prevent input blur on mousedown to avoid UI flickering

### DIFF
--- a/src/components/CreateTask/CreateTask.tsx
+++ b/src/components/CreateTask/CreateTask.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useState,
   ChangeEvent,
+  MouseEvent,
 } from 'react';
 import { PiPlusBold } from 'react-icons/pi';
 import Modal from '@components/Modal';
@@ -37,6 +38,11 @@ const CreateTask: FC = () => {
     setTaskText('');
   };
 
+  const handleKeepInputFocus = (event: MouseEvent<HTMLButtonElement>): void => {
+    // Prevent input blur on mousedown to avoid UI flickering
+    event.preventDefault();
+  };
+
   return (
     <>
       <form className={styles.form} onSubmit={handleSubmitTask}>
@@ -50,7 +56,11 @@ const CreateTask: FC = () => {
             ref={inputRef}
           />
         </div>
-        <button className={styles.submitButton} aria-label="Create">
+        <button
+          className={styles.submitButton}
+          aria-label="Create"
+          onMouseDown={handleKeepInputFocus}
+        >
           <PiPlusBold />
         </button>
       </form>

--- a/src/components/TaskItem/TaskItem.tsx
+++ b/src/components/TaskItem/TaskItem.tsx
@@ -7,6 +7,7 @@ import {
   Dispatch,
   KeyboardEvent,
   ChangeEvent,
+  MouseEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
 import { FaTrash, FaEdit, FaPlus } from 'react-icons/fa';
@@ -87,6 +88,11 @@ const TaskItem: FC<TaskItemProps> = memo(({ index, task, dispatch }) => {
     setEditTaskText(event.target.value);
   };
 
+  const handleKeepInputFocus = (event: MouseEvent<HTMLButtonElement>): void => {
+    // Prevent input blur on mousedown to avoid UI flickering
+    event.preventDefault();
+  };
+
   return (
     <>
       <Draggable draggableId={task.id} index={index} isDragDisabled={isEditing}>
@@ -131,6 +137,7 @@ const TaskItem: FC<TaskItemProps> = memo(({ index, task, dispatch }) => {
                 <button
                   className={styles.controlButton}
                   aria-label={isEditing ? 'Save' : 'Edit'}
+                  onMouseDown={handleKeepInputFocus}
                   onClick={isEditing ? handleSaveEdit : handleToggleEdit}
                 >
                   {isEditing ? <FaPlus /> : <FaEdit />}


### PR DESCRIPTION
**Note:** Firefox does not trigger `:active` transform animation on the submit button due to `preventDefault` on `mousedown`, which is used to prevent input blur and UI flicker.