### PR TITLE
fix: prevent interaction with background elements through task creation backdrop

### DIFF
--- a/src/components/CreateTask/CreateTask.module.scss
+++ b/src/components/CreateTask/CreateTask.module.scss
@@ -1,6 +1,10 @@
 .form {
   position: relative;
   margin-bottom: 30px;
+
+  &:focus-within {
+    touch-action: none;
+  }
 }
 
 .inputBackdrop {
@@ -15,10 +19,12 @@
     opacity: 0;
     transition: opacity 0.2s;
     pointer-events: none;
+    z-index: 5;
   }
 
   &:focus-within::before {
     opacity: 1;
+    pointer-events: auto;
   }
 }
 
@@ -33,7 +39,7 @@
   color: var(--theme-text-input);
   border: 2px solid transparent;
   transition: border 0.2s;
-  z-index: 1;
+  z-index: 6;
 
   &:focus {
     border: 2px solid #4484a8;
@@ -66,7 +72,7 @@
     transform 0.15s,
     box-shadow 0.15s;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
-  z-index: 2;
+  z-index: 7;
 
   @include hover-supported {
     &:hover {

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -16,6 +16,7 @@
   color: var(--theme-text-header);
   position: relative;
   z-index: 10;
+  touch-action: none;
 }
 
 .themeButton {


### PR DESCRIPTION
**Note:** Added `touch-action: none` via `:focus-within` on the task creation form and header to prevent overscroll/scroll-chaining issues on touch devices when the backdrop is active.